### PR TITLE
Fix missaligned track for some text languages

### DIFF
--- a/KAProgressLabel/KAProgressLabel.m
+++ b/KAProgressLabel/KAProgressLabel.m
@@ -120,8 +120,8 @@
 
 -(void)drawRect:(CGRect)rect
 {
-    [self drawProgressLabelCircleInRect:rect];
-    [super drawTextInRect:rect];
+    [self drawProgressLabelCircleInRect:self.bounds];
+    [super drawTextInRect:self.bounds];
 }
 
 #pragma mark - KVO


### PR DESCRIPTION
If the label's text was in some languages like Arabic, Chinese, Japanese, Korean, the track would get drawn incorrectly like in this screenshot:

![screenshot](https://cloud.githubusercontent.com/assets/5748627/10885761/76c12cb0-8187-11e5-815d-d4325b2aa0f9.jpg)

After some debugging, I found out that for my `82 x 82` progress label, the `drawRect:` method was getting called with the rect `(origin = (x = -1, y = -3), size = (width = 85.5, height = 89))`, whereas the `bounds` property was correctly set to `(origin = (x = 0, y = 0), size = (width = 82, height = 82))`.